### PR TITLE
feat(spec-msg):  Implement inclusion-tier match on relay chain

### DIFF
--- a/polkadot/primitives/src/v9/mod.rs
+++ b/polkadot/primitives/src/v9/mod.rs
@@ -1763,12 +1763,10 @@ pub mod node_features {
 		CandidateReceiptV2 = 3,
 		/// Enables support for scheduling information in the Candidate Descriptor.
 		CandidateReceiptV3 = 4,
-		/// Enables speculative messaging
-		SpeculativeMessaging = 5,
 		/// First unassigned feature bit.
 		/// Every time a new feature flag is assigned it should take this value.
 		/// and this should be incremented.
-		FirstUnassigned = 6,
+		FirstUnassigned = 5,
 	}
 
 	impl FeatureIndex {

--- a/polkadot/runtime/parachains/src/inclusion/benchmarking.rs
+++ b/polkadot/runtime/parachains/src/inclusion/benchmarking.rs
@@ -15,11 +15,12 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use bitvec::{bitvec, prelude::Lsb0};
+use codec::Encode;
 use frame_benchmarking::v2::*;
 use pallet_message_queue as mq;
 use polkadot_primitives::{
-	CandidateCommitments, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, HrmpChannelId,
-	OutboundHrmpMessage, SessionIndex,
+	CandidateCommitments, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, Hash,
+	HrmpChannelId, OutboundHrmpMessage, SessionIndex, StreamsRoot, UMPSignal, UMP_SEPARATOR,
 };
 
 use super::*;
@@ -113,7 +114,19 @@ mod benchmarks {
 		let head_data = HeadData(vec![0xFF; 1024]);
 
 		let relay_parent_number = BlockNumberFor::<T>::from(10_u32);
-		let commitments = create_candidate_commitments::<T>(para, head_data, max_len, u, h, c != 0);
+		let mut commitments =
+			create_candidate_commitments::<T>(para, head_data, max_len, u, h, c != 0);
+
+		// Speculative messaging: carry a `Provides` signal so `enact_candidate` records it into the
+		// sender's provides window, and pre-fill that window so the record hits its worst case (a
+		// full-window `RecentProvides` read + drop-oldest + write).
+		commitments.upward_messages.force_push(UMP_SEPARATOR);
+		commitments
+			.upward_messages
+			.force_push(UMPSignal::Provides(StreamsRoot(Hash::from_low_u64_be(u64::MAX))).encode());
+		for i in 0..MAX_PROVIDES_WINDOW_SIZE {
+			Pallet::<T>::record_provides(para, StreamsRoot(Hash::from_low_u64_be(i as u64)));
+		}
 		let backers = bitvec![u8, Lsb0; 1; backing_group_size as usize];
 		let availability_votes = bitvec![u8, Lsb0; 1; n_validators as usize];
 		let core_index = CoreIndex::from(0);

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -362,9 +362,10 @@ pub mod pallet {
 	/// Per-sender window of recently-committed `StreamsRoot`s for speculative messaging. Newest
 	/// entry last, at most [`MAX_PROVIDES_WINDOW_SIZE`] entries. A receiver's `requires` root
 	/// matches when it is present in the referenced source's window. Bare ring (no block tag): a
-	/// dispute revert is rolled back by the node's state-revert, so there is no explicit on-chain
-	/// eviction. A sender's window is dropped in full when it offboards (see
-	/// `initializer_on_new_session`), so it does not linger after the para is gone.
+	/// fork-revert dispute is unwound by the node's state-revert (no per-entry eviction); a *freeze*
+	/// (finalized-invalid candidate the node can't revert) clears the whole map on the freeze
+	/// transition (see `paras_inherent`), so an invalid root can't outlive `force_unfreeze`. A
+	/// sender's window is dropped in full when it offboards (see `initializer_on_new_session`).
 	#[pallet::storage]
 	pub(crate) type RecentProvides<T: Config> = StorageMap<
 		_,
@@ -979,8 +980,10 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Record a sender's committed `StreamsRoot` into its provides window at enactment, trimming to
-	/// [`MAX_PROVIDES_WINDOW_SIZE`] (drop-oldest). A dispute revert is handled by the node's
-	/// state-revert (see [`RecentProvides`]); there is no explicit eviction.
+	/// [`MAX_PROVIDES_WINDOW_SIZE`] (drop-oldest). A fork-revert is handled by the node's
+	/// state-revert; a freeze clears the whole map (see [`clear_provides`]). No per-entry eviction.
+	///
+	/// [`clear_provides`]: Self::clear_provides
 	pub(crate) fn record_provides(source: ParaId, root: StreamsRoot) {
 		RecentProvides::<T>::mutate(source, |window| {
 			// Drop oldest entries until there is room for one more within the window.
@@ -990,6 +993,17 @@ impl<T: Config> Pallet<T> {
 			// `window.len() < MAX_PROVIDES_WINDOW_SIZE`, so the push fits.
 			let _ = window.try_push(root);
 		});
+	}
+
+	/// Clear every sender's provides window — called on a dispute-induced **freeze** transition
+	/// (see `paras_inherent`). A finalized-invalid candidate cannot be reverted, so its committed
+	/// `StreamsRoot` would otherwise survive `force_unfreeze` (no rollback) and match a later
+	/// `requires`. Clearing the whole ring is safe here: a freeze only happens in the can't-revert
+	/// case, no candidates are included while frozen, and windows self-refill as senders re-provide
+	/// after unfreeze. The fork-revert path needs nothing — the node's state-revert unwinds the
+	/// writes with the abandoned branch.
+	pub(crate) fn clear_provides() {
+		let _ = RecentProvides::<T>::clear(u32::MAX, None);
 	}
 
 	pub(crate) fn relay_dispatch_queue_size(para_id: ParaId) -> (u32, u32) {

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -362,10 +362,11 @@ pub mod pallet {
 	/// Per-sender window of recently-committed `StreamsRoot`s for speculative messaging. Newest
 	/// entry last, at most [`MAX_PROVIDES_WINDOW_SIZE`] entries. A receiver's `requires` root
 	/// matches when it is present in the referenced source's window. Bare ring (no block tag): a
-	/// fork-revert dispute is unwound by the node's state-revert (no per-entry eviction); a *freeze*
-	/// (finalized-invalid candidate the node can't revert) clears the whole map on the freeze
-	/// transition (see `paras_inherent`), so an invalid root can't outlive `force_unfreeze`. A
-	/// sender's window is dropped in full when it offboards (see `initializer_on_new_session`).
+	/// fork-revert dispute is unwound by the node's state-revert (no per-entry eviction); a
+	/// *freeze* (finalized-invalid candidate the node can't revert) clears the whole map on the
+	/// freeze transition (see `paras_inherent`), so an invalid root can't outlive
+	/// `force_unfreeze`. A sender's window is dropped in full when it offboards (see
+	/// `initializer_on_new_session`).
 	#[pallet::storage]
 	pub(crate) type RecentProvides<T: Config> = StorageMap<
 		_,
@@ -970,13 +971,18 @@ impl<T: Config> Pallet<T> {
 		RecentProvides::<T>::get(source).iter().rev().any(|committed| committed == root)
 	}
 
-	/// Whether every `(source, StreamsRoot)` in `requires` is present in that source's provides
-	/// window — the relay-side match a receiver candidate must pass to be included.
-	pub(crate) fn requires_satisfied(requires: &RequiresSet) -> bool {
+	/// Match `requires` against the relay-side provides windows — the check a receiver candidate
+	/// must pass to be included. `Ok(())` if every `(source, StreamsRoot)` is present in that
+	/// source's window; otherwise `Err` with the first unmatched `(source, root)`, so the caller
+	/// can log exactly why the candidate was dropped.
+	pub(crate) fn requires_satisfied(requires: &RequiresSet) -> Result<(), (ParaId, StreamsRoot)> {
 		// Does one `RecentProvides` read per required source (≤ `MAX_SOURCES_PER_BLOCK` = 128).
-		requires
-			.iter()
-			.all(|(source, expected)| Self::provides_contains(*source, expected))
+		for (source, expected) in requires.iter() {
+			if !Self::provides_contains(*source, expected) {
+				return Err((*source, *expected));
+			}
+		}
+		Ok(())
 	}
 
 	/// Record a sender's committed `StreamsRoot` into its provides window at enactment, trimming to

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -382,13 +382,11 @@ pub mod pallet {
 
 const LOG_TARGET: &str = "runtime::inclusion";
 
-/// Maximum length of a sender's `provides` window for speculative messaging. The window holds the
-/// most-recent `StreamsRoot`s a sender has committed; a receiver's `requires` root matches when it
-/// is present here.
+/// Maximum length of a sender's `provides` window for speculative messaging. Holds the most-recent
+/// `StreamsRoot`s a sender has committed; a receiver's `requires` root matches when present here.
 ///
-/// Sized per the design (`W = 128`): W must cover the authoring→backing→inclusion pipeline
-/// *including elastic-scaling bursts* (up to ~36 sender blocks / 18 s at 500 ms block time), with
-/// ample slack. Cost is `W × 32 B` per sender (~4 KB), ~800 KB relay-wide at 200 parachains.
+/// `W = 128` must cover the authoring→backing→inclusion pipeline including elastic-scaling bursts,
+/// so a valid `requires` can't miss a still-recent `provides`; sized with slack.
 pub const MAX_PROVIDES_WINDOW_SIZE: u32 = 128;
 
 /// The reason that a candidate's outputs were rejected for.

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -363,12 +363,8 @@ pub mod pallet {
 	/// entry last, at most [`MAX_PROVIDES_WINDOW_SIZE`] entries. A receiver's `requires` root
 	/// matches when it is present in the referenced source's window. Bare ring (no block tag): a
 	/// dispute revert is rolled back by the node's state-revert, so there is no explicit on-chain
-	/// eviction.
-	///
-	/// NOTE(offboarding leak): the design prunes this window "as a whole when the sender
-	/// offboards", but that cleanup is **not yet wired** — an offboarded sender's entry lingers
-	/// indefinitely. Bounded, slow leak (≤ live-paras × W × 32 B, ≈ 4 KB/sender). Hook para
-	/// offboarding to `RecentProvides::remove(para)` before production.
+	/// eviction. A sender's window is dropped in full when it offboards (see
+	/// `initializer_on_new_session`), so it does not linger after the para is gone.
 	#[pallet::storage]
 	pub(crate) type RecentProvides<T: Config> = StorageMap<
 		_,
@@ -503,6 +499,12 @@ impl<T: Config> Pallet<T> {
 		for _ in PendingAvailability::<T>::drain() {}
 
 		Self::cleanup_outgoing_ump_dispatch_queues(outgoing_paras);
+
+		// Speculative messaging: drop the offboarded senders' provides windows so their entries
+		// don't linger in `RecentProvides` after the para is gone.
+		for outgoing_para in outgoing_paras {
+			RecentProvides::<T>::remove(outgoing_para);
+		}
 	}
 
 	pub(crate) fn cleanup_outgoing_ump_dispatch_queues(outgoing: &[ParaId]) {

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -48,8 +48,8 @@ use polkadot_primitives::{
 	BackedCandidate, CandidateCommitments, CandidateDescriptorV2 as CandidateDescriptor,
 	CandidateHash, CandidateReceiptV2 as CandidateReceipt,
 	CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreIndex, GroupIndex, HeadData,
-	Id as ParaId, SignedAvailabilityBitfields, SigningContext, UpwardMessage, ValidatorId,
-	ValidatorIndex, ValidityAttestation,
+	Id as ParaId, RequiresSet, SignedAvailabilityBitfields, SigningContext, StreamsRoot,
+	UpwardMessage, ValidatorId, ValidatorIndex, ValidityAttestation,
 };
 use scale_info::TypeInfo;
 use sp_runtime::{traits::One, DispatchError, SaturatedConversion, Saturating};
@@ -359,11 +359,41 @@ pub mod pallet {
 		VecDeque<CandidatePendingAvailability<T::Hash, BlockNumberFor<T>>>,
 	>;
 
+	/// Per-sender window of recently-committed `StreamsRoot`s for speculative messaging. Newest
+	/// entry last, at most [`MAX_PROVIDES_WINDOW_SIZE`] entries. A receiver's `requires` root
+	/// matches when it is present in the referenced source's window. Bare ring (no block tag): a
+	/// dispute revert is rolled back by the node's state-revert, so there is no explicit on-chain
+	/// eviction.
+	///
+	/// NOTE(offboarding leak): the design prunes this window "as a whole when the sender
+	/// offboards", but that cleanup is **not yet wired** — an offboarded sender's entry lingers
+	/// indefinitely. Bounded, slow leak (≤ live-paras × W × 32 B, ≈ 4 KB/sender). Hook para
+	/// offboarding to `RecentProvides::remove(para)` before production.
+	#[pallet::storage]
+	pub(crate) type RecentProvides<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		ParaId,
+		BoundedVec<StreamsRoot, ConstU32<MAX_PROVIDES_WINDOW_SIZE>>,
+		ValueQuery,
+	>;
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}
 }
 
 const LOG_TARGET: &str = "runtime::inclusion";
+
+/// Maximum length of a sender's `provides` window for speculative messaging. The window holds the
+/// most-recent `StreamsRoot`s a sender has committed; a receiver's `requires` root matches when it
+/// is present here.
+///
+/// Sized per the design (`W = 128`): W must cover the authoring→backing→inclusion pipeline
+/// *including elastic-scaling bursts* (up to ~36 sender blocks / 18 s at 500 ms block time), with
+/// ample slack. Cost is `W × 32 B` per sender (~4 KB), ~800 KB relay-wide at 200 parachains. The
+/// design makes W governance-adjustable via a `HostConfiguration` field; kept a `const` for the MVP
+/// (revisit if per-network tuning is needed).
+pub const MAX_PROVIDES_WINDOW_SIZE: u32 = 128;
 
 /// The reason that a candidate's outputs were rejected for.
 #[derive(Debug)]
@@ -856,6 +886,10 @@ impl<T: Config> Pallet<T> {
 		let commitments = receipt.commitments;
 		let config = configuration::ActiveConfig::<T>::get();
 
+		// Speculative messaging: parse the UMP signals up front, before any field of
+		// `commitments` is moved out below; a malformed signal set is treated as absent.
+		let provides = commitments.ump_signals().ok().and_then(|s| s.provides().copied());
+
 		T::RewardValidators::reward_backing(
 			backers
 				.iter()
@@ -903,6 +937,18 @@ impl<T: Config> Pallet<T> {
 			commitments.horizontal_messages,
 		);
 
+		// Record the sender's committed `StreamsRoot` into its provides window so a later
+		// receiver's `requires` can match it. One-phase (inclusion tier):
+		// requires are matched only at `sanitize_backed_candidates`; a dispute revert unwinds a
+		// reverted sender together with any receiver that consumed it via the node's state-revert
+		// (see `RecentProvides`), so there is no explicit eviction and no enactment-time re-check
+		// (that would be the hook for the speculative / optimistic tiers). A candidate carrying
+		// `provides` is only ever included with the feature enabled (the feature-off case is
+		// dropped at sanitize), so recording here needs no separate feature gate.
+		if let Some(root) = provides {
+			Self::record_provides(receipt.descriptor.para_id(), root);
+		}
+
 		Self::deposit_event(Event::<T>::CandidateIncluded(
 			plain,
 			commitments.head_data.clone(),
@@ -915,6 +961,39 @@ impl<T: Config> Pallet<T> {
 			commitments.head_data,
 			relay_parent_number,
 		);
+	}
+
+	/// Whether `root` is present in `source`'s provides window.
+	fn provides_contains(source: ParaId, root: &StreamsRoot) -> bool {
+		RecentProvides::<T>::get(source).iter().any(|committed| committed == root)
+	}
+
+	/// Whether every `(source, StreamsRoot)` in `requires` is present in that source's provides
+	/// window — the relay-side match a receiver candidate must pass to be included.
+	pub(crate) fn requires_satisfied(requires: &RequiresSet) -> bool {
+		// TODO(weights): unmetered — does up to `MAX_SOURCES_PER_BLOCK` (128) `RecentProvides`
+		// reads per candidate (the candidate author sizes the `RequiresSet`). Benchmark + weight
+		// the sanitize match, and account for it in the inherent weight, before production.
+		requires
+			.iter()
+			.all(|(source, expected)| Self::provides_contains(*source, expected))
+	}
+
+	/// Record a sender's committed `StreamsRoot` into its provides window at enactment, trimming to
+	/// [`MAX_PROVIDES_WINDOW_SIZE`] (drop-oldest). A dispute revert is handled by the node's
+	/// state-revert (see [`RecentProvides`]); there is no explicit eviction.
+	pub(crate) fn record_provides(source: ParaId, root: StreamsRoot) {
+		// TODO(weights): unmetered — one `RecentProvides` read+write per enacted provides-carrying
+		// candidate; not covered by the `enact_candidate` benchmark. Fold into that weight before
+		// production.
+		RecentProvides::<T>::mutate(source, |window| {
+			// Drop oldest entries until there is room for one more within the window.
+			while window.len() >= MAX_PROVIDES_WINDOW_SIZE as usize {
+				window.remove(0);
+			}
+			// `window.len() < MAX_PROVIDES_WINDOW_SIZE`, so the push fits.
+			let _ = window.try_push(root);
+		});
 	}
 
 	pub(crate) fn relay_dispatch_queue_size(para_id: ParaId) -> (u32, u32) {

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -971,9 +971,7 @@ impl<T: Config> Pallet<T> {
 	/// Whether every `(source, StreamsRoot)` in `requires` is present in that source's provides
 	/// window — the relay-side match a receiver candidate must pass to be included.
 	pub(crate) fn requires_satisfied(requires: &RequiresSet) -> bool {
-		// TODO(weights): unmetered — does up to `MAX_SOURCES_PER_BLOCK` (128) `RecentProvides`
-		// reads per candidate (the candidate author sizes the `RequiresSet`). Benchmark + weight
-		// the sanitize match, and account for it in the inherent weight, before production.
+		// Does one `RecentProvides` read per required source (≤ `MAX_SOURCES_PER_BLOCK` = 128).
 		requires
 			.iter()
 			.all(|(source, expected)| Self::provides_contains(*source, expected))
@@ -983,9 +981,6 @@ impl<T: Config> Pallet<T> {
 	/// [`MAX_PROVIDES_WINDOW_SIZE`] (drop-oldest). A dispute revert is handled by the node's
 	/// state-revert (see [`RecentProvides`]); there is no explicit eviction.
 	pub(crate) fn record_provides(source: ParaId, root: StreamsRoot) {
-		// TODO(weights): unmetered — one `RecentProvides` read+write per enacted provides-carrying
-		// candidate; not covered by the `enact_candidate` benchmark. Fold into that weight before
-		// production.
 		RecentProvides::<T>::mutate(source, |window| {
 			// Drop oldest entries until there is room for one more within the window.
 			while window.len() >= MAX_PROVIDES_WINDOW_SIZE as usize {

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -993,6 +993,9 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn record_provides(source: ParaId, root: StreamsRoot) {
 		RecentProvides::<T>::mutate(source, |window| {
 			// Drop oldest entries until there is room for one more within the window.
+			// `remove(0)` is O(n), but the shift is dominated by the whole-window SCALE
+			// decode/encode this `mutate` already does; a ring buffer would only complicate the
+			// newest-first short-circuit scan in `provides_contains` for no storage saving.
 			while window.len() >= MAX_PROVIDES_WINDOW_SIZE as usize {
 				window.remove(0);
 			}

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -386,9 +386,7 @@ const LOG_TARGET: &str = "runtime::inclusion";
 ///
 /// Sized per the design (`W = 128`): W must cover the authoring→backing→inclusion pipeline
 /// *including elastic-scaling bursts* (up to ~36 sender blocks / 18 s at 500 ms block time), with
-/// ample slack. Cost is `W × 32 B` per sender (~4 KB), ~800 KB relay-wide at 200 parachains. The
-/// design makes W governance-adjustable via a `HostConfiguration` field; kept a `const` for the MVP
-/// (revisit if per-network tuning is needed).
+/// ample slack. Cost is `W × 32 B` per sender (~4 KB), ~800 KB relay-wide at 200 parachains.
 pub const MAX_PROVIDES_WINDOW_SIZE: u32 = 128;
 
 /// The reason that a candidate's outputs were rejected for.
@@ -941,12 +939,10 @@ impl<T: Config> Pallet<T> {
 
 		// Record the sender's committed `StreamsRoot` into its provides window so a later
 		// receiver's `requires` can match it. One-phase (inclusion tier):
-		// requires are matched only at `sanitize_backed_candidates`; a dispute revert unwinds a
-		// reverted sender together with any receiver that consumed it via the node's state-revert
-		// (see `RecentProvides`), so there is no explicit eviction and no enactment-time re-check
-		// (that would be the hook for the speculative / optimistic tiers). A candidate carrying
-		// `provides` is only ever included with the feature enabled (the feature-off case is
-		// dropped at sanitize), so recording here needs no separate feature gate.
+		// requires are matched only at `sanitize_backed_candidates`; a candidate carrying
+		// `provides` reaches enactment only after passing sanitize with the feature enabled
+		// (the feature-off case is dropped at sanitize), so recording here needs no separate
+		// feature gate.
 		if let Some(root) = provides {
 			Self::record_provides(receipt.descriptor.para_id(), root);
 		}

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -965,7 +965,10 @@ impl<T: Config> Pallet<T> {
 
 	/// Whether `root` is present in `source`'s provides window.
 	fn provides_contains(source: ParaId, root: &StreamsRoot) -> bool {
-		RecentProvides::<T>::get(source).iter().any(|committed| committed == root)
+		// Scan newest-first: a `requires` almost always references a recent commitment, which sits
+		// at the tail of the drop-oldest window, so this short-circuits sooner on a match. (A miss
+		// still scans the whole window; the storage cost is one `get` either way.)
+		RecentProvides::<T>::get(source).iter().rev().any(|committed| committed == root)
 	}
 
 	/// Whether every `(source, StreamsRoot)` in `requires` is present in that source's provides

--- a/polkadot/runtime/parachains/src/inclusion/tests.rs
+++ b/polkadot/runtime/parachains/src/inclusion/tests.rs
@@ -3282,4 +3282,20 @@ mod speculative_provides_window {
 			assert!(!RecentProvides::<Test>::get(staying).is_empty());
 		});
 	}
+
+	#[test]
+	fn clear_provides_empties_every_window() {
+		new_test_ext(genesis_config(Vec::new())).execute_with(|| {
+			// Seed several senders' windows.
+			for src in 1..=3u32 {
+				ParaInclusion::record_provides(ParaId::from(src), sr(src as u8));
+			}
+			assert!((1..=3u32).all(|src| !RecentProvides::<Test>::get(ParaId::from(src)).is_empty()));
+
+			// A freeze transition clears the whole map (see `paras_inherent`).
+			ParaInclusion::clear_provides();
+
+			assert!((1..=3u32).all(|src| RecentProvides::<Test>::get(ParaId::from(src)).is_empty()));
+		});
+	}
 }

--- a/polkadot/runtime/parachains/src/inclusion/tests.rs
+++ b/polkadot/runtime/parachains/src/inclusion/tests.rs
@@ -3209,3 +3209,60 @@ fn check_validation_outputs_for_runtime_api_rejects_oversized_new_validation_cod
 		assert!(!ParaInclusion::check_validation_outputs_for_runtime_api(chain_a, 1, commitments,));
 	});
 }
+
+#[cfg(test)]
+mod speculative_provides_window {
+	//! Isolation tests for the relay-side speculative-messaging provides window: window
+	//! advance/trim and requires matching by root.
+	use super::*;
+	use polkadot_primitives::{RequiresSet, StreamsRoot};
+
+	fn sr(b: u8) -> StreamsRoot {
+		StreamsRoot(Hash::repeat_byte(b))
+	}
+
+	fn requires(entries: &[(u32, u8)]) -> RequiresSet {
+		RequiresSet::try_from_iter(
+			entries.iter().map(|(src, root)| (ParaId::from(*src), sr(*root))),
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn record_provides_trims_to_window_and_keeps_newest() {
+		new_test_ext(genesis_config(Vec::new())).execute_with(|| {
+			let source = ParaId::from(1000);
+			let total = MAX_PROVIDES_WINDOW_SIZE + 3;
+			for i in 0..total {
+				ParaInclusion::record_provides(source, sr(i as u8));
+			}
+			// The window holds exactly `MAX_PROVIDES_WINDOW_SIZE` entries.
+			assert_eq!(
+				RecentProvides::<Test>::get(source).len(),
+				MAX_PROVIDES_WINDOW_SIZE as usize
+			);
+			// The 3 oldest roots were dropped; roots from index 3 onward are retained.
+			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1000, 0)])));
+			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1000, 2)])));
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, 3)])));
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, (total - 1) as u8)])));
+		});
+	}
+
+	#[test]
+	fn requires_satisfied_needs_all_sources_and_exact_roots() {
+		new_test_ext(genesis_config(Vec::new())).execute_with(|| {
+			let (a, b) = (ParaId::from(1), ParaId::from(2));
+			ParaInclusion::record_provides(a, sr(0xA));
+			ParaInclusion::record_provides(b, sr(0xB));
+			// Both sources present with the right roots → satisfied.
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xB)])));
+			// Wrong root for a present source → not satisfied.
+			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xC)])));
+			// Unknown source → not satisfied.
+			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (3, 0xB)])));
+			// Empty requires → trivially satisfied.
+			assert!(ParaInclusion::requires_satisfied(&requires(&[])));
+		});
+	}
+}

--- a/polkadot/runtime/parachains/src/inclusion/tests.rs
+++ b/polkadot/runtime/parachains/src/inclusion/tests.rs
@@ -3265,4 +3265,21 @@ mod speculative_provides_window {
 			assert!(ParaInclusion::requires_satisfied(&requires(&[])));
 		});
 	}
+
+	#[test]
+	fn offboarding_clears_provides_window() {
+		new_test_ext(genesis_config(Vec::new())).execute_with(|| {
+			let (staying, leaving) = (ParaId::from(1), ParaId::from(2));
+			ParaInclusion::record_provides(staying, sr(0xA));
+			ParaInclusion::record_provides(leaving, sr(0xB));
+			assert!(!RecentProvides::<Test>::get(leaving).is_empty());
+
+			// A session change that offboards `leaving` drops its window; `staying` is untouched.
+			let notification = crate::initializer::SessionChangeNotification::default();
+			ParaInclusion::initializer_on_new_session(&notification, &[leaving]);
+
+			assert!(RecentProvides::<Test>::get(leaving).is_empty());
+			assert!(!RecentProvides::<Test>::get(staying).is_empty());
+		});
+	}
 }

--- a/polkadot/runtime/parachains/src/inclusion/tests.rs
+++ b/polkadot/runtime/parachains/src/inclusion/tests.rs
@@ -3242,10 +3242,12 @@ mod speculative_provides_window {
 				MAX_PROVIDES_WINDOW_SIZE as usize
 			);
 			// The 3 oldest roots were dropped; roots from index 3 onward are retained.
-			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1000, 0)])));
-			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1000, 2)])));
-			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, 3)])));
-			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, (total - 1) as u8)])));
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, 0)])).is_err());
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, 2)])).is_err());
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1000, 3)])).is_ok());
+			assert!(
+				ParaInclusion::requires_satisfied(&requires(&[(1000, (total - 1) as u8)])).is_ok()
+			);
 		});
 	}
 
@@ -3256,13 +3258,19 @@ mod speculative_provides_window {
 			ParaInclusion::record_provides(a, sr(0xA));
 			ParaInclusion::record_provides(b, sr(0xB));
 			// Both sources present with the right roots → satisfied.
-			assert!(ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xB)])));
-			// Wrong root for a present source → not satisfied.
-			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xC)])));
-			// Unknown source → not satisfied.
-			assert!(!ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (3, 0xB)])));
+			assert!(ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xB)])).is_ok());
+			// Wrong root for a present source → Err names that (source, root).
+			assert_eq!(
+				ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (2, 0xC)])),
+				Err((ParaId::from(2), sr(0xC))),
+			);
+			// Unknown source → Err names it.
+			assert_eq!(
+				ParaInclusion::requires_satisfied(&requires(&[(1, 0xA), (3, 0xB)])),
+				Err((ParaId::from(3), sr(0xB))),
+			);
 			// Empty requires → trivially satisfied.
-			assert!(ParaInclusion::requires_satisfied(&requires(&[])));
+			assert!(ParaInclusion::requires_satisfied(&requires(&[])).is_ok());
 		});
 	}
 
@@ -3290,7 +3298,9 @@ mod speculative_provides_window {
 			for src in 1..=3u32 {
 				ParaInclusion::record_provides(ParaId::from(src), sr(src as u8));
 			}
-			assert!((1..=3u32).all(|src| !RecentProvides::<Test>::get(ParaId::from(src)).is_empty()));
+			assert!(
+				(1..=3u32).all(|src| !RecentProvides::<Test>::get(ParaId::from(src)).is_empty())
+			);
 
 			// A freeze transition clears the whole map (see `paras_inherent`).
 			ParaInclusion::clear_provides();

--- a/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
@@ -18,13 +18,41 @@
 use super::*;
 use crate::{inclusion, ParaId};
 use alloc::collections::btree_map::BTreeMap;
+use codec::Encode;
 use core::cmp::{max, min};
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 
-use polkadot_primitives::{node_features::FeatureIndex, GroupIndex};
+use polkadot_primitives::{
+	node_features::FeatureIndex, v9::MAX_SOURCES_PER_BLOCK, CommittedCandidateReceiptV2,
+	GroupIndex, Hash, RequiresSet, StreamsRoot, UMPSignal,
+};
 
-use crate::builder::BenchBuilder;
+use crate::builder::{BenchBuilder, CandidateDescriptorVersionConfig};
+
+/// A worst-case speculative-messaging `Requires` set — `MAX_SOURCES_PER_BLOCK` entries — for the
+/// backed-candidate benchmark. The provides window must be seeded with these exact entries so the
+/// injected `Requires` matches and the candidate stays admitted.
+fn bench_requires_set() -> RequiresSet {
+	RequiresSet::try_from_iter(
+		(0..MAX_SOURCES_PER_BLOCK)
+			.map(|i| (ParaId::from(i), StreamsRoot(Hash::from_low_u64_be(i as u64)))),
+	)
+	.expect("MAX_SOURCES_PER_BLOCK entries fit the bound; qed")
+}
+
+/// Candidate modifier: append a worst-case `Requires` UMP signal so
+/// `enter_backed_candidates_variable` captures the per-candidate `requires`-match read cost (one
+/// `RecentProvides` read per source).
+fn add_requires_signal<H>(
+	mut candidate: CommittedCandidateReceiptV2<H>,
+) -> CommittedCandidateReceiptV2<H> {
+	candidate
+		.commitments
+		.upward_messages
+		.force_push(UMPSignal::Requires(bench_requires_set()).encode());
+	candidate
+}
 
 #[benchmarks]
 mod benchmarks {
@@ -139,13 +167,29 @@ mod benchmarks {
 			true,
 		)
 		.unwrap();
+		// Speculative messaging: enable the feature and make the backed candidate carry a
+		// worst-case `Requires` set (via the candidate modifier) against a fully-seeded provides
+		// window, so this benchmark captures the per-candidate `requires`-match read cost.
+		configuration::Pallet::<T>::set_node_feature(
+			RawOrigin::Root.into(),
+			FeatureIndex::SpeculativeMessaging as u8,
+			true,
+		)
+		.unwrap();
 		let cores_with_backed: BTreeMap<_, _> = vec![(0, v)] // The backed candidate will have `v` validity votes.
 			.into_iter()
 			.collect();
 
 		let scenario = BenchBuilder::<T>::new()
 			.set_backed_in_inherent_paras(cores_with_backed.clone())
+			.set_candidate_descriptor_version(CandidateDescriptorVersionConfig::V2)
+			.set_candidate_modifier(Some(add_requires_signal::<T::Hash>))
 			.build();
+
+		// Seed the provides window so the injected `Requires` matches (candidate stays admitted).
+		for (source, root) in bench_requires_set().iter() {
+			inclusion::Pallet::<T>::record_provides(*source, *root);
+		}
 
 		let mut benchmark = scenario.data.clone();
 

--- a/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
@@ -167,15 +167,10 @@ mod benchmarks {
 			true,
 		)
 		.unwrap();
-		// Speculative messaging: enable the feature and make the backed candidate carry a
-		// worst-case `Requires` set (via the candidate modifier) against a fully-seeded provides
-		// window, so this benchmark captures the per-candidate `requires`-match read cost.
-		configuration::Pallet::<T>::set_node_feature(
-			RawOrigin::Root.into(),
-			FeatureIndex::SpeculativeMessaging as u8,
-			true,
-		)
-		.unwrap();
+		// Speculative messaging: make the backed candidate carry a worst-case `Requires` set (via
+		// the candidate modifier) against a fully-seeded provides window, so this benchmark
+		// captures the per-candidate `requires`-match read cost. Processing is unconditional (no
+		// feature gate).
 		let cores_with_backed: BTreeMap<_, _> = vec![(0, v)] // The backed candidate will have `v` validity votes.
 			.into_iter()
 			.collect();

--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -619,7 +619,6 @@ impl<T: Config> Pallet<T> {
 
 		let node_features = configuration::ActiveConfig::<T>::get().node_features;
 		let v3_enabled = FeatureIndex::CandidateReceiptV3.is_set(&node_features);
-		let speculative_enabled = FeatureIndex::SpeculativeMessaging.is_set(&node_features);
 
 		let backed_candidates_with_core = sanitize_backed_candidates::<T>(
 			backed_candidates,
@@ -627,7 +626,6 @@ impl<T: Config> Pallet<T> {
 			concluded_invalid_hashes,
 			eligible,
 			v3_enabled,
-			speculative_enabled,
 		);
 		let count = count_backed_candidates(&backed_candidates_with_core);
 
@@ -1120,7 +1118,6 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 	concluded_invalid_with_descendants: BTreeSet<CandidateHash>,
 	scheduled: BTreeMap<ParaId, BTreeSet<CoreIndex>>,
 	v3_enabled: bool,
-	speculative_enabled: bool,
 ) -> BTreeMap<ParaId, Vec<(BackedCandidate<T::Hash>, CoreIndex)>> {
 	// Map the candidates to the right paraids, while making sure that the order between candidates
 	// of the same para is preserved.
@@ -1135,11 +1132,10 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 			continue;
 		}
 
-		// Speculative messaging: drop candidates carrying speculative UMP signals while the feature
-		// is disabled, and drop a candidate whose `requires` are not in the relay-side provides
-		// window. Dropping here breaks the para's chain, so descendants are dropped by
+		// Speculative messaging: drop a candidate whose `requires` are not in the relay-side
+		// provides window. Dropping here breaks the para's chain, so descendants are dropped by
 		// `filter_unchained_candidates` below (same as the other pre-chain filters).
-		if !check_speculative_messaging::<T>(&candidate, speculative_enabled) {
+		if !check_speculative_messaging::<T>(&candidate) {
 			continue;
 		}
 
@@ -1186,34 +1182,18 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 }
 
 /// Speculative-messaging admission check for one candidate. Returns `true` to keep the candidate:
-///
-/// - **feature off** — drop it if it carries any `Provides`/`Requires` UMP signal (fail-closed);
-/// - **feature on** — drop it if its `Requires` set is not fully present in the relay-side provides
-///   window (every `(source, StreamsRoot)` must be in that source's `RecentProvides`);
-/// - otherwise keep it. A malformed UMP-signal set is treated as no speculative signals (rejected
-///   separately by `check_descriptor_version_and_signals`).
+/// drop it if its `Requires` set is not fully present in the relay-side provides window (every
+/// `(source, StreamsRoot)` must be in that source's `RecentProvides`); otherwise keep it. A
+/// malformed UMP-signal set is treated as no speculative signals (rejected separately by
+/// `check_descriptor_version_and_signals`).
 ///
 /// Matches the *stored* window only (inclusion tier) — not co-arriving same-relay-block senders.
 fn check_speculative_messaging<T: crate::inclusion::Config>(
 	candidate: &BackedCandidate<T::Hash>,
-	speculative_enabled: bool,
 ) -> bool {
 	let Ok(signals) = candidate.candidate().commitments.ump_signals() else {
 		return true;
 	};
-
-	if !speculative_enabled {
-		if signals.provides().is_some() || signals.requires().is_some() {
-			log::debug!(
-				target: LOG_TARGET,
-				"Dropping candidate {:?} for para {:?}: speculative UMP signals while feature disabled.",
-				candidate.candidate().hash(),
-				candidate.descriptor().para_id(),
-			);
-			return false;
-		}
-		return true;
-	}
 
 	if let Some(requires) = signals.requires() {
 		if let Err((source, root)) = crate::inclusion::Pallet::<T>::requires_satisfied(requires) {

--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -441,10 +441,11 @@ impl<T: Config> Pallet<T> {
 		set_scrapable_on_chain_disputes::<T>(current_session, checked_disputes_sets.clone());
 
 		// Speculative messaging: on a *freeze* transition — a concluded-invalid dispute against a
-		// finalized candidate the node can't revert — clear the whole provides window. Otherwise the
-		// invalid sender's `StreamsRoot` survives `force_unfreeze` (no rollback) and a later
-		// `requires` could match it. The fork-revert path needs nothing here: the node's state-revert
-		// unwinds the writes with the abandoned branch (see `inclusion::RecentProvides`).
+		// finalized candidate the node can't revert — clear the whole provides window. Otherwise
+		// the invalid sender's `StreamsRoot` survives `force_unfreeze` (no rollback) and a later
+		// `requires` could match it. The fork-revert path needs nothing here: the node's
+		// state-revert unwinds the writes with the abandoned branch (see
+		// `inclusion::RecentProvides`).
 		if !was_frozen && T::DisputesHandler::is_frozen() {
 			inclusion::Pallet::<T>::clear_provides();
 		}
@@ -1215,12 +1216,14 @@ fn check_speculative_messaging<T: crate::inclusion::Config>(
 	}
 
 	if let Some(requires) = signals.requires() {
-		if !crate::inclusion::Pallet::<T>::requires_satisfied(requires) {
+		if let Err((source, root)) = crate::inclusion::Pallet::<T>::requires_satisfied(requires) {
 			log::debug!(
 				target: LOG_TARGET,
-				"Dropping candidate {:?} for para {:?}: requires not in provides window.",
+				"Dropping candidate {:?} for para {:?}: requires root {:?} not in source {:?}'s provides window.",
 				candidate.candidate().hash(),
 				candidate.descriptor().para_id(),
+				root,
+				source,
 			);
 			return false;
 		}

--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -436,6 +436,9 @@ impl<T: Config> Pallet<T> {
 
 		set_scrapable_on_chain_disputes::<T>(current_session, checked_disputes_sets.clone());
 
+		// Speculative messaging: no provides-window eviction here — a dispute revert is rolled back
+		// by the node's state-revert (see `inclusion::RecentProvides`).
+
 		if T::DisputesHandler::is_frozen() {
 			// Relay chain freeze, at this point we will not include any parachain blocks.
 			METRICS.on_relay_chain_freeze();
@@ -605,6 +608,7 @@ impl<T: Config> Pallet<T> {
 
 		let node_features = configuration::ActiveConfig::<T>::get().node_features;
 		let v3_enabled = FeatureIndex::CandidateReceiptV3.is_set(&node_features);
+		let speculative_enabled = FeatureIndex::SpeculativeMessaging.is_set(&node_features);
 
 		let backed_candidates_with_core = sanitize_backed_candidates::<T>(
 			backed_candidates,
@@ -612,6 +616,7 @@ impl<T: Config> Pallet<T> {
 			concluded_invalid_hashes,
 			eligible,
 			v3_enabled,
+			speculative_enabled,
 		);
 		let count = count_backed_candidates(&backed_candidates_with_core);
 
@@ -1104,6 +1109,7 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 	concluded_invalid_with_descendants: BTreeSet<CandidateHash>,
 	scheduled: BTreeMap<ParaId, BTreeSet<CoreIndex>>,
 	v3_enabled: bool,
+	speculative_enabled: bool,
 ) -> BTreeMap<ParaId, Vec<(BackedCandidate<T::Hash>, CoreIndex)>> {
 	// Map the candidates to the right paraids, while making sure that the order between candidates
 	// of the same para is preserved.
@@ -1115,6 +1121,14 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 			allowed_scheduling_parents,
 			v3_enabled,
 		) {
+			continue;
+		}
+
+		// Speculative messaging: drop candidates carrying speculative UMP signals while the feature
+		// is disabled, and drop a candidate whose `requires` are not in the relay-side provides
+		// window. Dropping here breaks the para's chain, so descendants are dropped by
+		// `filter_unchained_candidates` below (same as the other pre-chain filters).
+		if !check_speculative_messaging::<T>(&candidate, speculative_enabled) {
 			continue;
 		}
 
@@ -1158,6 +1172,55 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 	);
 
 	backed_candidates_with_core
+}
+
+/// Speculative-messaging admission check for one candidate. Returns `true` to keep the candidate:
+///
+/// - **feature off** — drop it if it carries any `Provides`/`Requires` UMP signal (migration
+///   safety: otherwise its `Provides` would seed the window with no matching performed);
+/// - **feature on** — drop it if its `Requires` set is not fully present in the relay-side provides
+///   window (every `(source, StreamsRoot)` must be in that source's `RecentProvides`);
+/// - otherwise keep it. A malformed UMP-signal set is treated as no speculative signals (rejected
+///   separately by `check_descriptor_version_and_signals`).
+///
+/// Matches against the *stored* window only — a `Requires` is satisfiable by a sender already
+/// enacted into the ring, not by a co-arriving same-relay-block sender. The design's virtually
+/// extended window (and the atomic enactment dependencies it needs) is only required for the
+/// live / speculative tier (same-relay-block co-arrival), so it is omitted here.
+fn check_speculative_messaging<T: crate::inclusion::Config>(
+	candidate: &BackedCandidate<T::Hash>,
+	speculative_enabled: bool,
+) -> bool {
+	let Ok(signals) = candidate.candidate().commitments.ump_signals() else {
+		return true;
+	};
+
+	if !speculative_enabled {
+		if signals.provides().is_some() || signals.requires().is_some() {
+			log::debug!(
+				target: LOG_TARGET,
+				"Dropping candidate {:?} for para {:?}: speculative UMP signals while feature disabled.",
+				candidate.candidate().hash(),
+				candidate.descriptor().para_id(),
+			);
+			return false;
+		}
+		return true;
+	}
+
+	if let Some(requires) = signals.requires() {
+		if !crate::inclusion::Pallet::<T>::requires_satisfied(requires) {
+			log::debug!(
+				target: LOG_TARGET,
+				"Dropping candidate {:?} for para {:?}: requires not in provides window.",
+				candidate.candidate().hash(),
+				candidate.descriptor().para_id(),
+			);
+			return false;
+		}
+	}
+
+	true
 }
 
 fn count_backed_candidates<B>(backed_candidates: &BTreeMap<ParaId, Vec<B>>) -> usize {

--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -421,6 +421,10 @@ impl<T: Config> Pallet<T> {
 			all_weight_after
 		};
 
+		// Whether the chain was already frozen before importing this block's disputes — used below
+		// to detect a fresh freeze transition for the speculative-messaging provides window.
+		let was_frozen = T::DisputesHandler::is_frozen();
+
 		// Note that `process_checked_multi_dispute_data` will iterate and import each
 		// dispute; so the input here must be reasonably bounded,
 		// which is guaranteed by the checks and weight limitation above.
@@ -436,8 +440,14 @@ impl<T: Config> Pallet<T> {
 
 		set_scrapable_on_chain_disputes::<T>(current_session, checked_disputes_sets.clone());
 
-		// Speculative messaging: no provides-window eviction here — a dispute revert is rolled back
-		// by the node's state-revert (see `inclusion::RecentProvides`).
+		// Speculative messaging: on a *freeze* transition — a concluded-invalid dispute against a
+		// finalized candidate the node can't revert — clear the whole provides window. Otherwise the
+		// invalid sender's `StreamsRoot` survives `force_unfreeze` (no rollback) and a later
+		// `requires` could match it. The fork-revert path needs nothing here: the node's state-revert
+		// unwinds the writes with the abandoned branch (see `inclusion::RecentProvides`).
+		if !was_frozen && T::DisputesHandler::is_frozen() {
+			inclusion::Pallet::<T>::clear_provides();
+		}
 
 		if T::DisputesHandler::is_frozen() {
 			// Relay chain freeze, at this point we will not include any parachain blocks.

--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -1176,17 +1176,13 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config>(
 
 /// Speculative-messaging admission check for one candidate. Returns `true` to keep the candidate:
 ///
-/// - **feature off** — drop it if it carries any `Provides`/`Requires` UMP signal (migration
-///   safety: otherwise its `Provides` would seed the window with no matching performed);
+/// - **feature off** — drop it if it carries any `Provides`/`Requires` UMP signal (fail-closed);
 /// - **feature on** — drop it if its `Requires` set is not fully present in the relay-side provides
 ///   window (every `(source, StreamsRoot)` must be in that source's `RecentProvides`);
 /// - otherwise keep it. A malformed UMP-signal set is treated as no speculative signals (rejected
 ///   separately by `check_descriptor_version_and_signals`).
 ///
-/// Matches against the *stored* window only — a `Requires` is satisfiable by a sender already
-/// enacted into the ring, not by a co-arriving same-relay-block sender. The design's virtually
-/// extended window (and the atomic enactment dependencies it needs) is only required for the
-/// live / speculative tier (same-relay-block co-arrival), so it is omitted here.
+/// Matches the *stored* window only (inclusion tier) — not co-arriving same-relay-block senders.
 fn check_speculative_messaging<T: crate::inclusion::Config>(
 	candidate: &BackedCandidate<T::Hash>,
 	speculative_enabled: bool,

--- a/polkadot/runtime/parachains/src/paras_inherent/tests.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/tests.rs
@@ -4542,6 +4542,7 @@ mod sanitizers {
 						BTreeSet::new(),
 						scheduled,
 						false,
+						false,
 					),
 					expected_backed_candidates_with_core,
 				);
@@ -4566,6 +4567,7 @@ mod sanitizers {
 						BTreeSet::new(),
 						scheduled,
 						v2_descriptor,
+						false,
 					),
 					expected_backed_candidates_with_core,
 				);
@@ -4587,6 +4589,7 @@ mod sanitizers {
 						&shared::AllowedSchedulingParents::<Test>::get(),
 						BTreeSet::new(),
 						scheduled,
+						false,
 						false,
 					),
 					expected_backed_candidates_with_core
@@ -4617,6 +4620,7 @@ mod sanitizers {
 						&shared::AllowedSchedulingParents::<Test>::get(),
 						BTreeSet::new(),
 						scheduled,
+						false,
 						false,
 					),
 					expected_backed_candidates_with_core
@@ -4657,6 +4661,7 @@ mod sanitizers {
 					&shared::AllowedSchedulingParents::<Test>::get(),
 					BTreeSet::new(),
 					scheduled,
+					false,
 					false,
 				);
 
@@ -4724,6 +4729,7 @@ mod sanitizers {
 					BTreeSet::new(),
 					scheduled,
 					false,
+					false,
 				);
 
 				assert_eq!(res.len(), 1);
@@ -4755,6 +4761,7 @@ mod sanitizers {
 					BTreeSet::new(),
 					scheduled,
 					v2_descriptor,
+					false,
 				);
 
 				assert!(sanitized_backed_candidates.is_empty());
@@ -4786,6 +4793,7 @@ mod sanitizers {
 					&shared::AllowedSchedulingParents::<Test>::get(),
 					set,
 					scheduled,
+					false,
 					false,
 				);
 
@@ -4826,6 +4834,7 @@ mod sanitizers {
 					invalid_set,
 					scheduled,
 					v2_descriptor,
+					false,
 				);
 
 				// We'll be left with candidates from paraid 2 and 4.
@@ -4862,6 +4871,7 @@ mod sanitizers {
 					invalid_set,
 					scheduled,
 					v2_descriptor,
+					false,
 				);
 
 				// Only the second candidate of paraid 1 should be removed.
@@ -5179,5 +5189,96 @@ mod sanitizers {
 				assert_eq!(candidate_receipt_with_backing_validator_indices.len(), untouched.len());
 			});
 		}
+	}
+}
+
+#[cfg(test)]
+mod speculative_admission_gate {
+	//! Candidate-level tests for the `check_speculative_messaging` sanitize gate: feature-off drops
+	//! candidates carrying speculative UMP signals; feature-on matches their `Requires` against the
+	//! relay-side provides window.
+	use super::{check_speculative_messaging, default_config};
+	use crate::{
+		inclusion::tests::TestCandidateBuilder,
+		mock::{new_test_ext, Test},
+	};
+	use codec::Encode;
+	use polkadot_primitives::{
+		BackedCandidate, CoreIndex, Id as ParaId, RequiresSet, StreamsRoot, UMPSignal,
+	};
+
+	fn sr(b: u8) -> StreamsRoot {
+		StreamsRoot(polkadot_primitives::Hash::repeat_byte(b))
+	}
+
+	fn requires(source: u32, root: u8) -> RequiresSet {
+		RequiresSet::try_from_iter([(ParaId::from(source), sr(root))]).unwrap()
+	}
+
+	/// A V2 candidate (which auto-carries a `SelectCore` signal), optionally also carrying
+	/// `Provides` / `Requires` speculative signals.
+	fn candidate(
+		para: u32,
+		provides: Option<StreamsRoot>,
+		requires: Option<RequiresSet>,
+	) -> BackedCandidate {
+		let mut builder = TestCandidateBuilder::default();
+		builder.para_id = ParaId::from(para);
+		builder.core_index = Some(CoreIndex(0));
+		let mut ccr = builder.build();
+		if let Some(r) = requires {
+			ccr.commitments.upward_messages.force_push(UMPSignal::Requires(r).encode());
+		}
+		if let Some(p) = provides {
+			ccr.commitments.upward_messages.force_push(UMPSignal::Provides(p).encode());
+		}
+		BackedCandidate::new(ccr.into(), Default::default(), Default::default(), CoreIndex(0))
+	}
+
+	#[test]
+	fn feature_off_drops_speculative_candidates_keeps_plain() {
+		new_test_ext(default_config()).execute_with(|| {
+			// Carrying `Requires` or `Provides` while the feature is off → dropped (migration
+			// safety).
+			assert!(!check_speculative_messaging::<Test>(
+				&candidate(2000, None, Some(requires(1000, 0xA))),
+				false,
+			));
+			assert!(!check_speculative_messaging::<Test>(
+				&candidate(2000, Some(sr(0xB)), None),
+				false,
+			));
+			// A plain candidate (no speculative signals, just `SelectCore`) is kept.
+			assert!(check_speculative_messaging::<Test>(&candidate(2000, None, None), false));
+		});
+	}
+
+	#[test]
+	fn feature_on_matches_requires_against_window() {
+		new_test_ext(default_config()).execute_with(|| {
+			let source = 1000;
+			crate::inclusion::Pallet::<Test>::record_provides(ParaId::from(source), sr(0xA));
+
+			// `Requires` present in the source's window → kept.
+			assert!(check_speculative_messaging::<Test>(
+				&candidate(2000, None, Some(requires(source, 0xA))),
+				true,
+			));
+			// `Requires` with the wrong root → not in window → dropped.
+			assert!(!check_speculative_messaging::<Test>(
+				&candidate(2000, None, Some(requires(source, 0xC))),
+				true,
+			));
+			// `Requires` for an unknown source → dropped.
+			assert!(!check_speculative_messaging::<Test>(
+				&candidate(2000, None, Some(requires(9999, 0xA))),
+				true,
+			));
+			// No `Requires` (only `Provides`) → nothing to match → kept.
+			assert!(check_speculative_messaging::<Test>(
+				&candidate(2000, Some(sr(0xB)), None),
+				true,
+			));
+		});
 	}
 }

--- a/polkadot/runtime/parachains/src/paras_inherent/tests.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/tests.rs
@@ -4542,7 +4542,6 @@ mod sanitizers {
 						BTreeSet::new(),
 						scheduled,
 						false,
-						false,
 					),
 					expected_backed_candidates_with_core,
 				);
@@ -4567,7 +4566,6 @@ mod sanitizers {
 						BTreeSet::new(),
 						scheduled,
 						v2_descriptor,
-						false,
 					),
 					expected_backed_candidates_with_core,
 				);
@@ -4589,7 +4587,6 @@ mod sanitizers {
 						&shared::AllowedSchedulingParents::<Test>::get(),
 						BTreeSet::new(),
 						scheduled,
-						false,
 						false,
 					),
 					expected_backed_candidates_with_core
@@ -4620,7 +4617,6 @@ mod sanitizers {
 						&shared::AllowedSchedulingParents::<Test>::get(),
 						BTreeSet::new(),
 						scheduled,
-						false,
 						false,
 					),
 					expected_backed_candidates_with_core
@@ -4661,7 +4657,6 @@ mod sanitizers {
 					&shared::AllowedSchedulingParents::<Test>::get(),
 					BTreeSet::new(),
 					scheduled,
-					false,
 					false,
 				);
 
@@ -4729,7 +4724,6 @@ mod sanitizers {
 					BTreeSet::new(),
 					scheduled,
 					false,
-					false,
 				);
 
 				assert_eq!(res.len(), 1);
@@ -4761,7 +4755,6 @@ mod sanitizers {
 					BTreeSet::new(),
 					scheduled,
 					v2_descriptor,
-					false,
 				);
 
 				assert!(sanitized_backed_candidates.is_empty());
@@ -4793,7 +4786,6 @@ mod sanitizers {
 					&shared::AllowedSchedulingParents::<Test>::get(),
 					set,
 					scheduled,
-					false,
 					false,
 				);
 
@@ -4834,7 +4826,6 @@ mod sanitizers {
 					invalid_set,
 					scheduled,
 					v2_descriptor,
-					false,
 				);
 
 				// We'll be left with candidates from paraid 2 and 4.
@@ -4871,7 +4862,6 @@ mod sanitizers {
 					invalid_set,
 					scheduled,
 					v2_descriptor,
-					false,
 				);
 
 				// Only the second candidate of paraid 1 should be removed.
@@ -5236,49 +5226,31 @@ mod speculative_admission_gate {
 	}
 
 	#[test]
-	fn feature_off_drops_speculative_candidates_keeps_plain() {
-		new_test_ext(default_config()).execute_with(|| {
-			// Carrying `Requires` or `Provides` while the feature is off → dropped (migration
-			// safety).
-			assert!(!check_speculative_messaging::<Test>(
-				&candidate(2000, None, Some(requires(1000, 0xA))),
-				false,
-			));
-			assert!(!check_speculative_messaging::<Test>(
-				&candidate(2000, Some(sr(0xB)), None),
-				false,
-			));
-			// A plain candidate (no speculative signals, just `SelectCore`) is kept.
-			assert!(check_speculative_messaging::<Test>(&candidate(2000, None, None), false));
-		});
-	}
-
-	#[test]
-	fn feature_on_matches_requires_against_window() {
+	fn matches_requires_against_window() {
 		new_test_ext(default_config()).execute_with(|| {
 			let source = 1000;
 			crate::inclusion::Pallet::<Test>::record_provides(ParaId::from(source), sr(0xA));
 
 			// `Requires` present in the source's window → kept.
-			assert!(check_speculative_messaging::<Test>(
-				&candidate(2000, None, Some(requires(source, 0xA))),
-				true,
-			));
+			assert!(check_speculative_messaging::<Test>(&candidate(
+				2000,
+				None,
+				Some(requires(source, 0xA)),
+			)));
 			// `Requires` with the wrong root → not in window → dropped.
-			assert!(!check_speculative_messaging::<Test>(
-				&candidate(2000, None, Some(requires(source, 0xC))),
-				true,
-			));
+			assert!(!check_speculative_messaging::<Test>(&candidate(
+				2000,
+				None,
+				Some(requires(source, 0xC)),
+			)));
 			// `Requires` for an unknown source → dropped.
-			assert!(!check_speculative_messaging::<Test>(
-				&candidate(2000, None, Some(requires(9999, 0xA))),
-				true,
-			));
+			assert!(!check_speculative_messaging::<Test>(&candidate(
+				2000,
+				None,
+				Some(requires(9999, 0xA)),
+			)));
 			// No `Requires` (only `Provides`) → nothing to match → kept.
-			assert!(check_speculative_messaging::<Test>(
-				&candidate(2000, Some(sr(0xB)), None),
-				true,
-			));
+			assert!(check_speculative_messaging::<Test>(&candidate(2000, Some(sr(0xB)), None)));
 		});
 	}
 }


### PR DESCRIPTION
Resolves paritytech/polkadot-sdk#12349.

Relay-chain side of Speculative Messaging — the **inclusion-tier** match between a sender's `Provides` and a receiver's `Requires`.

## What it does
- **inclusion pallet** — `RecentProvides`, a bounded per-sender ring of recent `StreamsRoot`s (`BoundedVec<_, ConstU32<128>>`). `record_provides` pushes at `enact_candidate` (from the `Provides` UMP signal); `requires_satisfied` does the windowed membership match (scanned newest-first).
- **paras_inherent** — `check_speculative_messaging` in `sanitize_backed_candidates`, gated on `FeatureIndex::SpeculativeMessaging`: feature-off drops any candidate carrying speculative signals (fail-closed); feature-on drops a candidate whose `Requires` aren't in the window.

## Design notes
- **No dispute eviction** — `RecentProvides` is ordinary storage rolled back by the node's state-revert with the chain; a receiver only matches an *ancestor* sender, so both revert together.
- **Offboarding** — the window is dropped in the `initializer_on_new_session` per-outgoing-para cleanup.
- **Weights** — the per-candidate `requires_satisfied` reads (≤128) and the `record_provides` read+write are captured by extending the existing `enter_backed_candidates_variable` / `enact_candidate` benchmarks to hit the worst case; the numbers come from a CI weight regeneration (`/cmd bench`), not a hand-written weight adjustment.

## Scope
Inclusion tier only: a `Requires` matches a sender **already enacted into the window**, not a co-arriving same-relay-block sender (the speculative/optimistic tiers are future work). This is the **relay half** — the receiver-side PoV-lift is separate parachain work.

## Tests
Window trim + requires matching + offboarding (isolation)
